### PR TITLE
Updating links for FMH and WMO references

### DIFF
--- a/README
+++ b/README
@@ -48,10 +48,12 @@ METAR specifications
 The Federal Meteorological Handbook No.1. (FMH-1 1995), which
 describes the U.S. standards, is available online at
 
-   http://www.ofcm.gov/fmh-1/fmh1.htm
+   http://www.ofcm.gov/publications/fmh/FMH1/FMH1.pdf
 
-I'm not sure from where you can download the World Meteorological
-Organization (WMO) Manual on Codes, vol I.1, Part A (WMO-306 I.i.A)
+You can download the World Meteorological Organization (WMO) Manual 
+on Codes, vol I.1, Part A (WMO-306 I.i.A) at
+
+   http://www.wmo.int/pages/prog/www/WMOCodes.html
 
 Tom Pollard
 pollard@alum.mit.edu


### PR DESCRIPTION
I found that the FMH link seems to have died, but in the process of finding a working link found what appears to be the WMO code standards also. 