### PR TITLE
improve sky_conditions string formatting logic

### DIFF
--- a/metar/Metar.py
+++ b/metar/Metar.py
@@ -1216,12 +1216,14 @@ class Metar(object):
                   what = "clouds"
               else: 
                   what = ""
+              label = "%s %s" % (SKY_COVER[cover], what)
+              # HACK here to account for 'empty' entries with above format
+              label = " ".join(label.strip().split())
               if cover == "VV":
-                  text_list.append("%s%s, vertical visibility to %s" % 
-                          (SKY_COVER[cover],what,str(height)))
+                  label += ", vertical visibility to %s" % (str(height), )
               else:
-                  text_list.append("%s%s at %s" % 
-                          (SKY_COVER[cover],what,str(height)))
+                  label += " at %s" % (str(height), )
+              text_list.append(label)
       return sep.join(text_list)
           
   def trend( self ):

--- a/test/test_metar.py
+++ b/test/test_metar.py
@@ -457,6 +457,9 @@ class MetarTest(unittest.TestCase):
     self.assertEqual( report('SCT030').sky_conditions(), 'scattered clouds at 3000 feet' )
     self.assertEqual( report('BKN001').sky_conditions(), 'broken clouds at 100 feet' )
     self.assertEqual( report('OVC008').sky_conditions(), 'overcast at 800 feet' )
+    self.assertEqual(
+      report('OVC010CB').sky_conditions(), 'overcast cumulonimbus at 1000 feet'
+    )
     self.assertEqual( report('SCT020TCU').sky_conditions(), 'scattered towering cumulus at 2000 feet' )
     self.assertEqual( report('BKN015CB').sky_conditions(), 'broken cumulonimbus at 1500 feet' )
     self.assertEqual( report('FEW030').sky_conditions(), 'a few clouds at 3000 feet' )


### PR DESCRIPTION
should prevent phrases like `sky: overcastcumulonimbus at 1000 feet`
closes #41