### PR TITLE
Fixed references to Federal Meteorological Handbook No.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ where `cycle` is a 2-digit cycle number (`00` thru `23`).
 METAR specifications
 --------------------
 
-The [Federal Meteorological Handbook No.1. (FMH-1 1995)](http://www.ofcm.gov/publications/fmh/FMH1/FMH1.pdf) describes the U.S. standards for METAR. The [World Meteorological Organization (WMO) Manual on Codes](http://www.wmo.int/pages/prog/www/WMOCodes.html), vol I.1, Part A (WMO-306 I.i.A) is another good reference.
+The [Federal Meteorological Handbook No.1. (FMC-H1-2017)](http://www.ofcm.gov/publications/fmh/FMH1/FMH1.pdf) describes the U.S. standards for METAR. The [World Meteorological Organization (WMO) Manual on Codes](http://www.wmo.int/pages/prog/www/WMOCodes.html), vol I.1, Part A (WMO-306 I.i.A) is another good reference.
 
 Author
 ------

--- a/metar/__init__.py
+++ b/metar/__init__.py
@@ -5,7 +5,7 @@
 
 US conventions for METAR/SPECI reports are described in chapter 12 of
 the Federal Meteorological Handbook No.1. (FMH-1 1995), issued by NOAA.
-See <http://metar.noaa.gov/>
+See http://www.ofcm.gov/publications/fmh/FMH1/FMH1.pdf
 
 International conventions for the METAR and SPECI codes are specified in
 the WMO Manual on Codes, vol I.1, Part A (WMO-306 I.i.A).

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ METAR is an international format for reporting weather observations.
 The standard specification for the METAR and SPECI codes is given
 in the WMO Manual on Codes, vol I.1, Part A (WMO-306 I.i.A).  US
 conventions for METAR/SPECI reports are described in chapter 12 of
-the Federal Meteorological Handbook No.1. (FMH-1 1995), issued by
-NOAA.  See http://www.ncdc.noaa.gov/oa/wdc/metar/
+the Federal Meteorological Handbook No.1. (FMC-H1-2017), issued by
+NOAA.  See http://www.ofcm.gov/publications/fmh/FMH1/FMH1.pdf
 
 This module extracts the data recorded in the main-body groups of
 reports that follow the WMO spec or the US conventions, except for


### PR DESCRIPTION
This just fixes the broken link to the US METAR spec in setup.py.  That doc is now referred to as FMC-H1-2017, and so I updated that, too, in both the README and setup.py