### PR TITLE
Allow for repeated TREND groups

### DIFF
--- a/metar/Metar.py
+++ b/metar/Metar.py
@@ -1045,7 +1045,7 @@ class Metar(object):
         (WINDSHEAR_RE, _handleWindShear, True),
         (COLOR_RE, _handleColor, True),
         (RUNWAYSTATE_RE, _handleRunwayState, True),
-        (TREND_RE, _handleTrend, False),
+        (TREND_RE, _handleTrend, True),
         (REMARK_RE, _startRemarks, False),
     ]
 

--- a/test/test_metar.py
+++ b/test/test_metar.py
@@ -39,6 +39,16 @@ def test_module():
     assert hasattr(metar, "__version__")
 
 
+def test_issue114_multiplebecominggroups():
+    """multiple BECMG (becoming) groups should be possible"""
+    code = (
+        "METAR WSSS 280900Z 26009KT 180V350 0600 R20R/1900D R20C/1600D +TSRA FEW008 SCT013CB FEW015TCU 24/23 Q1010 "
+        "BECMG FM0920 TL0930 3000 TSRA "
+        "BECMG FM1000 TL1020 6000 NSW"
+    )
+    assert Metar.Metar(code).decode_completed
+
+
 @pytest.mark.parametrize("trailstr", ["", "=", "=  "])
 def test_issue84_trimequals(trailstr):
     """A trailing = in METAR should not trip up the ingest."""

--- a/test/test_metar.py
+++ b/test/test_metar.py
@@ -46,7 +46,11 @@ def test_issue114_multiplebecominggroups():
         "BECMG FM0920 TL0930 3000 TSRA "
         "BECMG FM1000 TL1020 6000 NSW"
     )
-    assert Metar.Metar(code).decode_completed
+
+    metar = Metar.Metar(code)
+    assert metar.decode_completed
+    assert len(metar._trend_groups) == 10
+    assert metar.trend() == "BECMG FM0920 TL0930 3000 TSRA BECMG FM1000 TL1020 6000 NSW"
 
 
 @pytest.mark.parametrize("trailstr", ["", "=", "=  "])


### PR DESCRIPTION
This fixes #114 by allowing multiple TREND groups to occur. Since I am just starting with understanding and parsing METAR, please check, if this is OK.

This change now also allows for multiple NOSIG indicators. Would this be OK, or should there be a dedicated group for this case?