### PR TITLE
Fix runway not parsing //// See issue #26

### DIFF
--- a/metar/Metar.py
+++ b/metar/Metar.py
@@ -684,7 +684,7 @@ class Metar(object):
             return
         unit = d["unit"] if d["unit"] is not None else "M"
         if d["low"] == "////":
-            low = distance(-999, unit)
+            return
         else:
             low = distance(d["low"], unit)
         if d["high"] is None:

--- a/metar/Metar.py
+++ b/metar/Metar.py
@@ -64,7 +64,7 @@ VISIBILITY_RE = re.compile(
 RUNWAY_RE = re.compile(
     r"""^(RVRNO |
         R(?P<name>\d\d(RR?|LL?|C)?)/
-        (?P<low>(M|P)?\d\d\d\d)
+        (?P<low>(M|P)?(\d\d\d\d|/{4}))
         (V(?P<high>(M|P)?\d\d\d\d))?
         (?P<unit>FT)?[/NDU]*)\s+""",
     re.VERBOSE,
@@ -683,7 +683,10 @@ class Metar(object):
         if d["name"] is None:
             return
         unit = d["unit"] if d["unit"] is not None else "M"
-        low = distance(d["low"], unit)
+        if d["low"] == "////":
+            low = distance(-999, unit)
+        else:
+            low = distance(d["low"], unit)
         if d["high"] is None:
             high = low
         else:

--- a/test/test_metar.py
+++ b/test/test_metar.py
@@ -127,12 +127,12 @@ def test_issue107_runwayunits():
 
 @pytest.mark.parametrize("RVR", ["R28L/////", "R28L/////FT", "R28L//////", "R28L/////N"])
 def test_issue26_runway_slashes(RVR):
-    """Check RVR with slashes decoding to missing value set as -999."""
+    """Check RVR with slashes decoding."""
     report = Metar.Metar(
-        "METAR KPIT 091955Z COR 22015G25KT 3/4SM {} TSRA OVC010CB "
+        "METAR KPIT 091955Z COR 22015G25KT 3/4SM R28L/2600FT {} TSRA OVC010CB "
         "18/16 A2992 RMK SLP045 T1820160".format(RVR)
     )
-    assert pytest.approx(report.runway[0][1].value()) == -999.0
+    assert len(report.runway) == 1
 
 def test_010_parseType_default():
     """Check default value of the report type."""

--- a/test/test_metar.py
+++ b/test/test_metar.py
@@ -125,6 +125,15 @@ def test_issue107_runwayunits():
     res = report.runway_visual_range("FT")
     assert res == "on runway 28L, 4921 feet"
 
+@pytest.mark.parametrize("RVR", ["R28L/////", "R28L/////FT", "R28L//////", "R28L/////N"])
+def test_issue26_runway_slashes(RVR):
+    """Check RVR with slashes decoding to missing value set as -999."""
+    report = Metar.Metar(
+        "METAR KPIT 091955Z COR 22015G25KT 3/4SM {} TSRA OVC010CB "
+        "18/16 A2992 RMK SLP045 T1820160".format(RVR)
+    )
+    assert pytest.approx(report.runway[0][1].value()) == -999.0
+
 def test_010_parseType_default():
     """Check default value of the report type."""
     assert Metar.Metar("KEWR").type == "METAR"


### PR DESCRIPTION
This adds the slashes to the runway regex and then handles them in the runway handler to be decoded to -999. Probably it would be good to change this value or catch this as an exception.