### PR TITLE
fix parsing of R/SNOCLO runway state and adapt tests

### DIFF
--- a/metar/Metar.py
+++ b/metar/Metar.py
@@ -109,12 +109,13 @@ COLOR_RE = re.compile(
     re.VERBOSE,
 )
 RUNWAYSTATE_RE = re.compile(
-    r"""((?P<name>\d\d) | R(?P<namenew>\d\d)(RR?|LL?|C)?/?)
-        ((?P<special> SNOCLO|CLRD(\d\d|//)) |
+    r"""((?P<snoclo>R/SNOCLO) |
+        ((?P<name>\d\d) | R(?P<namenew>\d\d)?(RR?|LL?|C)?/?)
+        ((?P<special>CLRD(\d\d|//)) |
         (?P<deposit>(\d|/))
         (?P<extent>(\d|/))
         (?P<depth>(\d\d|//))
-        (?P<friction>(\d\d|//)))\s+""",
+        (?P<friction>(\d\d|//))))\s+""",
     re.VERBOSE,
 )
 TREND_RE = re.compile(r"^(?P<trend>TEMPO|BECMG|FCST|NOSIG)\s+")

--- a/metar/Metar.py
+++ b/metar/Metar.py
@@ -110,8 +110,8 @@ COLOR_RE = re.compile(
 )
 RUNWAYSTATE_RE = re.compile(
     r"""((?P<snoclo>R/SNOCLO) |
-        ((?P<name>\d\d) | R(?P<namenew>\d\d)?(RR?|LL?|C)?/?)
-        ((?P<special>CLRD(\d\d|//)) |
+        ((?P<name>\d\d) | R(?P<namenew>\d\d)(RR?|LL?|C)?/?)
+        ((?P<special> SNOCLO|CLRD(\d\d|//)) |
         (?P<deposit>(\d|/))
         (?P<extent>(\d|/))
         (?P<depth>(\d\d|//))

--- a/test/test_metar.py
+++ b/test/test_metar.py
@@ -38,6 +38,14 @@ def test_module():
     """Test that module level things are defined."""
     assert hasattr(metar, "__version__")
 
+def test_issue119_r_snoclo():
+    """There is no runway designator in the R/SNOCLO special group"""
+    code_right = "METAR EDDC 032220Z 31005KT 5000 -SN BKN008 M01/M01 Q1020 R/SNOCLO"
+    code_wrong = "METAR EDDC 032220Z 31005KT 5000 -SN BKN008 M01/M01 Q1020 R04/SNOCLO"
+
+    assert Metar.Metar(code_right).decode_completed
+    assert not Metar.Metar(code_wrong, strict=False).decode_completed
+
 
 def test_issue114_multiplebecominggroups():
     """multiple BECMG (becoming) groups should be possible"""
@@ -553,8 +561,8 @@ def test_290_ranway_state():
     assert report("09690692 27550591").temp.value() == -1.0
     assert report("09690692 27550591").remarks() == ""
 
-    assert report("09SNOCLO").remarks() == ""
-    assert report("09CLRD//").remarks() == ""
+    assert report("R/SNOCLO").remarks() == ""
+    assert report("R09/CLRD//").remarks() == ""
 
 
 def test_300_parseTrend():

--- a/test/test_metar.py
+++ b/test/test_metar.py
@@ -38,14 +38,6 @@ def test_module():
     """Test that module level things are defined."""
     assert hasattr(metar, "__version__")
 
-def test_issue119_r_snoclo():
-    """There is no runway designator in the R/SNOCLO special group"""
-    code_right = "METAR EDDC 032220Z 31005KT 5000 -SN BKN008 M01/M01 Q1020 R/SNOCLO"
-    code_wrong = "METAR EDDC 032220Z 31005KT 5000 -SN BKN008 M01/M01 Q1020 R04/SNOCLO"
-
-    assert Metar.Metar(code_right).decode_completed
-    assert not Metar.Metar(code_wrong, strict=False).decode_completed
-
 
 def test_issue114_multiplebecominggroups():
     """multiple BECMG (becoming) groups should be possible"""
@@ -561,8 +553,13 @@ def test_290_ranway_state():
     assert report("09690692 27550591").temp.value() == -1.0
     assert report("09690692 27550591").remarks() == ""
 
+    assert report("09SNOCLO").remarks() == ""
+    assert report("09CLRD//").remarks() == ""
+
     assert report("R/SNOCLO").remarks() == ""
     assert report("R09/CLRD//").remarks() == ""
+
+    assert report("R01R/SNOCLO ").remarks() == ""
 
 
 def test_300_parseTrend():


### PR DESCRIPTION
This fixes #119, based on the [Manual on Codes](https://library.wmo.int/doc_num.php?explnum_id=10235) sections FM 15-XV/FM 16-XV and 15.13.6.

I also had to adapt an existing test case in which the R/SNOCLO runway state group was wrong.