### PR TITLE
Added a 'COR AUTO' case for modifier

### DIFF
--- a/metar/Metar.py
+++ b/metar/Metar.py
@@ -43,7 +43,7 @@ TIME_RE = re.compile(
         (?P<min>\d\d)Z?\s+""",
     re.VERBOSE,
 )
-MODIFIER_RE = re.compile(r"^(?P<mod>AUTO|FINO|NIL|TEST|CORR?|RTD|CC[A-G])\s+")
+MODIFIER_RE = re.compile(r"^(?P<mod>AUTO|COR AUTO|FINO|NIL|TEST|CORR?|RTD|CC[A-G])\s+")
 WIND_RE = re.compile(
     r"""^(?P<dir>[\dO]{3}|[0O]|///|MMM|VRB)
         (?P<speed>P?[\dO]{2,3}|[/M]{2,3})

--- a/test/test_metar.py
+++ b/test/test_metar.py
@@ -602,3 +602,11 @@ def test_not_strict_mode():
     assert report.station_id == "K9L2"
     assert report.vis.value() == 10
     assert report.sky_conditions() == "clear"
+
+def test_cor_auto_mod():
+    code = """METAR KADW 252356Z COR AUTO 10008KT 10SM CLR 19/11 A2986
+    RMK AO2 SLP117 T01880111 10230 20188 50004 $ COR
+    0007="""
+    m=Metar.Metar(code,year=2019)
+
+    assert m.mod=='COR AUTO'


### PR DESCRIPTION
Adjusted the modifier re to parse METARs containing a 'COR AUTO' modifier. Makes it possible to parse METARs such as this:

METAR KADW 252356Z COR AUTO 10008KT 10SM CLR 19/11 A2986
           RMK AO2 SLP117 T01880111 10230 20188 50004 $ COR
           0007=

Fixes #121 