### PR TITLE
set wind speed defaults when no units provided

### DIFF
--- a/metar/Metar.py
+++ b/metar/Metar.py
@@ -618,6 +618,14 @@ class Metar(object):
             self.wind_dir = direction(wind_dir)
         wind_speed = d["speed"].replace("O", "0")
         units = d["units"]
+        # Ambiguous METAR when no wind speed units are provided
+        if units is None and self.station_id is not None:
+            # Assume US METAR sites are reporting in KT
+            if len(self.station_id) == 3 or self.station_id.startswith("K"):
+                units = "KT"
+        # If units are still None, default to MPS
+        if units is None:
+            units = "MPS"
         if units == "KTS" or units == "K" or units == "T" or units == "LT":
             units = "KT"
         if wind_speed.startswith("P"):

--- a/test/test_metar.py
+++ b/test/test_metar.py
@@ -367,7 +367,8 @@ def test_141_parseWind_nonstd():
     assert report("09010T").wind_speed.string() == "10 knots"
     assert report("09010LT").wind_speed.string() == "10 knots"
     assert report("09010KTS").wind_speed.string() == "10 knots"
-    assert report("09010").wind_speed.string() == "10 mps"
+    # Default wind speed units are knots since US station_id is used
+    assert report("09010").wind_speed.string() == "10 knots"
 
     assert report("VRBOOK").wind_speed.value() == 0
     assert report("VRBOOK").wind() == "calm"
@@ -388,6 +389,12 @@ def test_141_parseWind_nonstd():
     assert report("MMMMM").wind() == "missing"
     assert report("MMMMMGMMKT").wind() == "missing"
     assert report("MMMMMG01KT").wind() == "missing"
+
+
+def test_issue139_no_wind_unit():
+    """Check the default wind speed units for international sites."""
+    report = Metar.Metar("CXXX 101651Z 09010G20")
+    assert report.wind_speed.string() == "10 mps"
 
 
 def test_issue51_strict():


### PR DESCRIPTION
- For US-sites, default to KT.
- For all others, default to MPS.

closes #139