### PR TITLE
Enable parsing of METARs that list wind and visibility after the sky condition groups.

### DIFF
--- a/metar/Metar.py
+++ b/metar/Metar.py
@@ -1050,6 +1050,8 @@ class Metar(object):
         (RUNWAY_RE, _handleRunway, True),
         (WEATHER_RE, _handleWeather, True),
         (SKY_RE, _handleSky, True),
+        (WIND_RE, _handleWind, False),
+        (VISIBILITY_RE, _handleVisibility, True),
         (TEMP_RE, _handleTemp, False),
         (PRESS_RE, _handlePressure, True),
         (RECENT_RE, _handleRecent, True),

--- a/test/test_metar.py
+++ b/test/test_metar.py
@@ -653,3 +653,17 @@ def test_cor_auto_mod():
     m = Metar.Metar(code, year=2019)
 
     assert m.mod == 'COR AUTO'
+
+def test_wind_after_sky():
+    """
+    Test parsing of a METAR that lists wind after the sky groups
+    """
+
+    code = (
+        "METAR KCOF 281855Z FEW029TCU FEW040 SCT250 09008KT 7SM 32/25 A3008 "
+        "RMK VIRGA E TCU NE AND DSNT ALQDS SLP186"
+    )
+    m = Metar.Metar(code, year=2007)
+
+    assert m.wind_dir.value() == 90
+    assert m.wind_speed.value() == 8


### PR DESCRIPTION
Add an extra copy of the wind and visibility, to enable parsing of METARs that list wind and visibility after the sky condition groups.

Fixes #147.