### PR TITLE
Enable parsing of METARs that list sea level pressure after the altimeter setting rather than in the remarks.

### DIFF
--- a/metar/Metar.py
+++ b/metar/Metar.py
@@ -1052,6 +1052,7 @@ class Metar(object):
         (SKY_RE, _handleSky, True),
         (TEMP_RE, _handleTemp, False),
         (PRESS_RE, _handlePressure, True),
+        (SEALVL_PRESS_RE, _handleSealvlPressRemark, False),
         (RECENT_RE, _handleRecent, True),
         (WINDSHEAR_RE, _handleWindShear, True),
         (COLOR_RE, _handleColor, True),

--- a/test/test_metar.py
+++ b/test/test_metar.py
@@ -653,3 +653,16 @@ def test_cor_auto_mod():
     m = Metar.Metar(code, year=2019)
 
     assert m.mod == 'COR AUTO'
+
+def test_slp_outside_remarks():
+    """
+    Test parsing of a METAR that lists sea level pressure after the altimeter
+    setting instead of in the remarks.
+    """
+
+    code = (
+        "METAR KCOF 191855Z 18015G22KT 7SM FEW049 SCT300 28/18 A3001 SLP162 "
+        "RMK WND DATA ESTMD"
+    )
+    m = Metar.Metar(code, year=2007)
+    m.press_sea_level.value() == 1016.2


### PR DESCRIPTION
Although sea level pressure (SLP) groups are normally found in the remarks section, in rare cases the SLP group can be found after the altimeter setting. This PR allows enables parsing of METARs that are structured in this way.

Fixes #148.