### PR TITLE
illegal temperature will raise ParserError

### DIFF
--- a/metar/Metar.py
+++ b/metar/Metar.py
@@ -85,8 +85,8 @@ SKY_RE = re.compile(
     re.VERBOSE,
 )
 TEMP_RE = re.compile(
-    r"""^(?P<temp>(M|-)?\d+|//|XX|MM)/
-        (?P<dewpt>(M|-)?\d+|//|XX|MM)?\s+""",
+    r"""^(?P<temp>(M|-)?\d{1,2}|//|XX|MM)/
+        (?P<dewpt>(M|-)?\d{1,2}|//|XX|MM)?\s+""",
     re.VERBOSE,
 )
 PRESS_RE = re.compile(

--- a/test/test_metar.py
+++ b/test/test_metar.py
@@ -653,3 +653,7 @@ def test_cor_auto_mod():
     m = Metar.Metar(code, year=2019)
 
     assert m.mod == 'COR AUTO'
+
+
+def test_issue136_temperature():
+    raisesParserError("METAR EDDM 022150Z 26006KT CAVOK 201/16")


### PR DESCRIPTION
Values for temperature and dew point should be 2 digits only. According to [this comment](https://github.com/python-metar/python-metar/issues/136#issuecomment-822518301) it might be beneficial to allow 1-digit values as well.

This fixes #136 .