### PR TITLE
Test on python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,24 +6,30 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version:
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+          - '3.12-dev'
     steps:
     - uses: actions/checkout@v3
-
-    - name: Monolith Workflow
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Package
       run: |
-        wget -q https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -O miniforge.sh
-        bash miniforge.sh -f -b -p $HOME/miniconda
-        . $HOME/miniconda/etc/profile.d/conda.sh
-        conda config --set quiet True --set always_yes yes --set changeps1 no
-        conda create --name testenv --yes python=${{ matrix.python-version }} pip six pytest pytest-runner pytest-cov pytest-runner
-        conda activate testenv
+        python -m pip install --upgrade setuptools setuptools_scm wheel
         python -m pip install .
+    - name: Run Tests
+      run: |
+        python -m pip install pytest pytest-runner pytest-cov pytest-runner
         python setup.py test --addopts " --cov=metar"
         if [[ ${{ matrix.python-version }} == "3.8" ]]; then
           pip install codecov
           codecov
         fi
+
   typing:
     name: Typing Check
     runs-on: ubuntu-latest

--- a/metar/Metar.py
+++ b/metar/Metar.py
@@ -417,7 +417,7 @@ class Metar(object):
         self._unparsed_groups = []
         self._unparsed_remarks = []
 
-        self._now = datetime.datetime.utcnow()
+        self._now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
         if utcdelta:
             self._utcdelta = utcdelta
         else:

--- a/misc/getstation.py
+++ b/misc/getstation.py
@@ -31,7 +31,7 @@ def usage():
     sys.exit(1)
 
 
-today = datetime.datetime.utcnow()
+today = datetime.datetime.now(datetime.timezone.utc)
 
 stations = []
 pipe = False

--- a/test/test_metar.py
+++ b/test/test_metar.py
@@ -1,6 +1,6 @@
 """Test the main Metar Library."""
 import warnings
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 import metar
@@ -11,7 +11,7 @@ sta_time = "KEWR 101651Z "
 sta_time_mod = "KEWR 101651Z AUTO "
 sta_time_wind = "KEWR 101651Z 00000KT "
 
-today = datetime.utcnow()
+today = datetime.now(timezone.utc)
 tomorrow = today + timedelta(days=1)
 
 


### PR DESCRIPTION
- Use `setup-python` GHA to provide python
- Address `utcnow()` deprecation in #175