### PR TITLE
denote METAR 1.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+metar-1.11.0 (5 July 2023)
+
+This release adds a missing type hint and supports Python 3.12.
+
+- [#174](https://github.com/python-metar/python-metar/pull/174) Fix Type Hints.
+- [#176](https://github.com/python-metar/python-metar/pull/176) Python 3.12.
+
 metar-1.10.0 (18 May 2023)
 
 This release adds type hints and supports Python 3.11.

--- a/metar/__init__.py
+++ b/metar/__init__.py
@@ -28,7 +28,7 @@ __author__ = "Tom Pollard"
 
 __email__ = "pollard@alum.mit.edu"
 
-__version__ = "1.10.0"
+__version__ = "1.11.0"
 
 __doc__ = """metar v%s (c) 2009, %s
 


### PR DESCRIPTION
I'm sympathetic to cutting a new release so to get ahead of any python 3.12 testing and to fix the type hinting.