### PR TITLE
fix: add code translation to no significant weather, nsw

### DIFF
--- a/metar/Metar.py
+++ b/metar/Metar.py
@@ -286,6 +286,7 @@ WEATHER_OTHER = {
     "FC": "funnel cloud",
     "SS": "sandstorm",
     "DS": "dust storm",
+    "NSW": "no significant weather",
 }
 
 WEATHER_SPECIAL = {"+FC": "tornado"}

--- a/test/test_metar.py
+++ b/test/test_metar.py
@@ -699,3 +699,34 @@ def test_windshear_runway_identifier():
     assert len(m.windshear) == 1
     assert m.windshear[0] == "22L"
 
+
+def test_present_weather_others():
+    # PO, sand whirls
+    code = "VEIM 301200Z 16007KT 7000 PO SCT018 31/27 Q1007 NOSIG"
+    m = Metar.Metar(code, month=8, year=2023)
+    assert m.present_weather() == 'sand whirls'
+
+    # SQ, squalls
+    code = "VEIM 301200Z 16007KT 7000 SQ SCT018 31/27 Q1007 NOSIG"
+    m = Metar.Metar(code, month=8, year=2023)
+    assert m.present_weather() == 'squalls'
+
+    # FC, funnel cloud
+    code = "VEIM 301200Z 16007KT 7000 FC SCT018 31/27 Q1007 NOSIG"
+    m = Metar.Metar(code, month=8, year=2023)
+    assert m.present_weather() == 'funnel cloud'
+
+    # SS, sandstorm
+    code = "VEIM 301200Z 16007KT 7000 SS SCT018 31/27 Q1007 NOSIG"
+    m = Metar.Metar(code, month=8, year=2023)
+    assert m.present_weather() == 'sandstorm'
+
+    # DS, dust storm
+    code = "VEIM 301200Z 16007KT 7000 DS SCT018 31/27 Q1007 NOSIG"
+    m = Metar.Metar(code, month=8, year=2023)
+    assert m.present_weather() == 'dust storm'
+
+    # NSW, No significant weather
+    code = "VEIM 301200Z 16007KT 7000 NSW SCT018 31/27 Q1007 NOSIG"
+    m = Metar.Metar(code, month=8, year=2023)
+    assert m.present_weather() == 'no significant weather'


### PR DESCRIPTION
Code tested: VEIM 301200Z 16007KT 7000 NSW SCT018 31/27 Q1007 NOSIG
Before:
![image](https://github.com/python-metar/python-metar/assets/22323331/18160528-7964-4cdd-928f-9a22aa85b702)

After:
![image](https://github.com/python-metar/python-metar/assets/22323331/d974e98c-c6c9-4837-b66d-9d09a014bf66)
