### PR TITLE
Ensure T-group temperatures are consistent with previously parsed temperatures

### DIFF
--- a/metar/Metar.py
+++ b/metar/Metar.py
@@ -153,7 +153,7 @@ PRESS_3HR_RE = re.compile(
 (?P<press>\d\d\d)\s+""",
     re.VERBOSE,
 )
-TEMP_1HR_RE = re.compile(
+TEMP_TGROUP_RE = re.compile(
     r"""^T(?P<tsign>0|1)
         (?P<temp>\d\d\d)
         ((?P<dsign>0|1)
@@ -882,7 +882,7 @@ class Metar(object):
         value = float(d["precip"]) / 100.0
         self.precip_1hr = precipitation(value, "IN")
 
-    def _handleTemp1hrRemark(self, d):
+    def _handleTempTgroupRemark(self, d):
         """
         Parse a temperature & dewpoint remark group.
 
@@ -1084,7 +1084,7 @@ class Metar(object):
         (WIND_SHIFT_RE, _handleWindShiftRemark),
         (LIGHTNING_RE, _handleLightningRemark),
         (TS_LOC_RE, _handleTSLocRemark),
-        (TEMP_1HR_RE, _handleTemp1hrRemark),
+        (TEMP_TGROUP_RE, _handleTempTgroupRemark),
         (PRECIP_1HR_RE, _handlePrecip1hrRemark),
         (PRECIP_24HR_RE, _handlePrecip24hrRemark),
         (PRESS_3HR_RE, _handlePress3hrRemark),

--- a/metar/Metar.py
+++ b/metar/Metar.py
@@ -888,14 +888,27 @@ class Metar(object):
 
         These values replace the temp and dewpt from the body of the report.
         """
+        def _checkT(current, newvalue, label):
+            """Helper."""
+            if current and abs(newvalue - current.value()) > 1:
+                raise ValueError(
+                    f"{label} from T group ({newvalue:.1f}) does not "
+                    "agree with previously parsed value of "
+                    f"{current.value():.0f}"
+                )
+
         value = float(d["temp"]) / 10.0
         if d["tsign"] == "1":
             value = -value
+        # Ensure that Tgroup value rounds to integer provided temperature
+        _checkT(self.temp, value, "Temperature")
         self.temp = temperature(value)
         if d["dewpt"]:
             value2 = float(d["dewpt"]) / 10.0
             if d["dsign"] == "1":
                 value2 = -value2
+            # Ensure that Tgroup value rounds to integer provided dewpoint
+            _checkT(self.dewpt, value2, "Dew Point")
             self.dewpt = temperature(value2)
 
     def _handleTemp6hrRemark(self, d):

--- a/test/test_metar.py
+++ b/test/test_metar.py
@@ -39,6 +39,19 @@ def test_module():
     assert hasattr(metar, "__version__")
 
 
+def test_issue182_conflicting_temperatures():
+    """Test that a T-group with conflicting temperatures raises an error."""
+    # IRL
+    code = (
+        "KRDU 081851Z 33003KT 10SM SCT030 SCT120 BKN200 "
+        "35/24 A3004 RMK T03440339"
+    )
+    with pytest.raises(Metar.ParserError):
+        Metar.Metar(code, 7, 2024, strict=True)
+    mtr = Metar.Metar(code, 7, 2024, strict=False)
+    assert mtr.dewpt.value() == 24.0
+
+
 def test_issue114_multiplebecominggroups():
     """multiple BECMG (becoming) groups should be possible"""
     code = (


### PR DESCRIPTION
My feelings would not be hurt if this PR is rejected by the reviewers here.  This PR also includes a related change to update the hopefully only internally used labels to define what the T-group is.  It was likely a previous copy/paste as Temp1Hour

closes #182 