### PR TITLE
Remove unused/misleading utcdelta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 *.swp
 .tox/
+.venv
 htmlcov/
 .coverage
 /build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 *.pyc
 *.swp
 .tox/
-.venv
 htmlcov/
 .coverage
+/.venv/
 /build/
 /dist/
+/python_metar.egg-info/
 /metar.egg-info/

--- a/metar/Datatypes.py
+++ b/metar/Datatypes.py
@@ -1,10 +1,9 @@
 # Copyright (c) 2004,2018 Python-Metar Developers.
 # Distributed under the terms of the BSD 2-Clause License.
 # SPDX-License-Identifier: BSD-2-Clause
-"""Python classes to represent dimensioned quantities used in weather reports.
-"""
+"""Python classes to represent dimensioned quantities used in weather reports."""
 import re
-from math import sin, cos, atan2, sqrt
+from math import pi, sin, cos, atan2
 
 # exceptions
 
@@ -481,7 +480,7 @@ class position(object):
         long2 = position2.longitude
         s = -sin(long1 - long2) * cos(lat2)
         c = cos(lat1) * sin(lat2) - sin(lat1) * cos(lat2) * cos(long1 - long2)
-        d = atan2(s, c) * 180.0 / math.pi
+        d = atan2(s, c) * 180.0 / pi
         if d < 0.0:
             d += 360.0
         return direction(d)

--- a/metar/Metar.py
+++ b/metar/Metar.py
@@ -352,7 +352,7 @@ debug = False
 class Metar(object):
     """METAR (aviation meteorology report)"""
 
-    def __init__(self, metarcode, month=None, year=None, utcdelta=None, strict=True):
+    def __init__(self, metarcode, month=None, year=None, strict=True):
         """
         Parse raw METAR code.
 
@@ -362,8 +362,6 @@ class Metar(object):
         month, year : int, optional
           Date values to be used when parsing a non-current METAR code. If not
           provided, then the month and year are guessed from the current date.
-        utcdelta : int or datetime.timedelta, optional
-          An int of hours or a timedelta object used to specify the timezone.
         strict : bool (default is True)
           This option determines if a ``ParserError`` is raised when
           unparsable groups are found or an unexpected exception is encountered.
@@ -419,10 +417,6 @@ class Metar(object):
         self._unparsed_remarks = []
 
         self._now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
-        if utcdelta:
-            self._utcdelta = utcdelta
-        else:
-            self._utcdelta = datetime.datetime.now() - self._now
 
         self._month = month
         self._year = year

--- a/metar/Metar.pyi
+++ b/metar/Metar.pyi
@@ -74,7 +74,6 @@ class Metar:
         metarcode: str,
         month: Optional[int] = ...,
         year: Optional[int] = ...,
-        utcdelta: Union[int, timedelta, None] = ...,
         strict: bool = ...,
     ): ...
     @property


### PR DESCRIPTION
This PR removes the unused `utcdelta`, which leads to confusion around whether timezones are handled naively or not. 

Even though code-wise this is a small change, I'd suggest a major semver bump to 2.0.0 as it's a breaking change to the Metar constructor.

This has some overlap with https://github.com/python-metar/python-metar/pull/186; however, that PR suggests broader changes to how timezones are handled, and the utcdelta arg is misleading enough that I believe it should be removed regardless of the decision on how to handle zulu time.